### PR TITLE
Add PostgreSQL schema for users, teams, plans

### DIFF
--- a/backend/app/common/db_schema/create_tables.sql
+++ b/backend/app/common/db_schema/create_tables.sql
@@ -1,0 +1,24 @@
+CREATE TABLE plans (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(50) NOT NULL UNIQUE,  -- Free, Basic, Pro
+    max_users INTEGER NOT NULL,
+    can_ai_summary BOOLEAN DEFAULT FALSE,
+    can_readiness_check BOOLEAN DEFAULT FALSE,
+    can_export BOOLEAN DEFAULT FALSE,
+    weekly_search_limit INTEGER DEFAULT NULL  -- null = unlimited
+);
+CREATE TABLE teams (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(100) NOT NULL,
+    plan_id INTEGER REFERENCES plans(id),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    team_id UUID REFERENCES teams(id) ON DELETE CASCADE,
+    full_name VARCHAR(100) NOT NULL,
+    email VARCHAR(150) UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    is_admin BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/app/common/db_schema/seed_plans.sql
+++ b/backend/app/common/db_schema/seed_plans.sql
@@ -1,0 +1,5 @@
+INSERT INTO plans (name, max_users, can_ai_summary, can_readiness_check, can_export, weekly_search_limit)
+VALUES 
+  ('Free', 1, FALSE, FALSE, FALSE, 3),
+  ('Basic', 3, TRUE, TRUE, FALSE, NULL),
+  ('Pro', 9999, TRUE, TRUE, TRUE, NULL);


### PR DESCRIPTION
Implemented PostgreSQL schema for core tables:

plans: SaaS tiers (Free, Basic, Pro)

teams: Org structure

users: Members linked to teams
Includes seed data for plans.